### PR TITLE
Revamp caching

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,10 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
+      "env": {
+        // Uncomment the line below to turn on debug logging
+        // "ZONEINFO_DEBUG": "true"
+      },
       "outFiles": [
         "${workspaceFolder}/out/src/**/*.js"
       ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Change Log
 All notable changes to this project will be documented in this file (the format is based on [Keep a Changelog](http://keepachangelog.com/)).
+Development-only changes (e.g. updates to `devDependencies`) will not be listed here, as they don’t affect the public features.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### BREAKING CHANGES
-- Updated minimum supported VS Code version to 1.50
+- Updated minimum supported VS Code version to 1.50.
+
+### Changed
+- Improved startup performance by deferring/lazy-loading file parsing.
 
 ## 2.1.1 - 2018-02-07
 ### Fixed

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,0 +1,16 @@
+import { performance } from 'perf_hooks';
+
+export function timer(): (label: string) => void {
+  const start = performance.now();
+  let prevMark: number;
+  return (label: string) => {
+    let mark = performance.now();
+    let logLabel = `  {time ${label}}`;
+    if (prevMark) {
+      console.log(logLabel, mark - prevMark, mark - start);
+    } else {
+      console.log(logLabel, mark - start);
+    }
+    prevMark = mark;
+  }
+}

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,15 +1,32 @@
 import { performance } from 'perf_hooks';
 
+const shouldLog = 'ZONEINFO_DEBUG' in process.env;
+
+export function log(...msgs: unknown[]): void {
+  if (shouldLog) {
+    console.log(...msgs);
+  }
+}
+
+function round(n: number): number {
+  return Math.round(n * 1e3) / 1e3;
+}
+
 export function timer(): (label: string) => void {
+  if (!shouldLog) {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    return () => {};
+  }
+  
   const start = performance.now();
   let prevMark: number;
   return (label: string) => {
     let mark = performance.now();
     let logLabel = `  {time ${label}}`;
     if (prevMark) {
-      console.log(logLabel, mark - prevMark, mark - start);
+      console.log(logLabel, round(mark - prevMark), round(mark - start));
     } else {
-      console.log(logLabel, mark - start);
+      console.log(logLabel, round(mark - start));
     }
     prevMark = mark;
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,15 +28,17 @@ export function deactivate(): void {
 }
 
 async function workspaceFoldersChanged(e: vscode.WorkspaceFoldersChangeEvent) {
-  // await Promise.all(
-  //   e.added.map(async (folder) => {
-  //     await symbols.cacheWorkspaceFolder(folder);
-  //   }),
-  // );
-  // e.removed.forEach((folder) => {
-  //   symbols.clearWorkspaceFolderCache(folder);
-  // });
-  // symbols.syncWorkspaceCache();
+  // Clear any cached folder/document symbols for removed folders
+  e.removed.forEach((folder) => {
+    symbols.removeForFolder(folder);
+  });
+  // Parse and cache new folders, but only if the whole workspace has been previously cached.
+  // Otherwise, rely on the usual lazy-loading behaviour within a folder.
+  if (symbols.hasCachedWorkspace()) {
+    e.added.forEach((folder) => {
+      symbols.getForFolder(folder);
+    });
+  }
 }
 
 // function documentChanged(e: vscode.TextDocumentChangeEvent) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,8 +17,8 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.languages.registerDefinitionProvider(ZONEINFO_MODE, new ZoneinfoDefinitionProvider()),
     vscode.languages.registerReferenceProvider(ZONEINFO_MODE, new ZoneinfoReferenceProvider()),
     vscode.workspace.onDidChangeWorkspaceFolders(workspaceFoldersChanged),
-    vscode.workspace.onDidChangeTextDocument(documentChanged),
-    vscode.workspace.onDidSaveTextDocument(documentSaved),
+    // vscode.workspace.onDidChangeTextDocument(documentChanged),
+    // vscode.workspace.onDidSaveTextDocument(documentSaved),
   );
   // process.nextTick(symbols.cacheCurrentWorkspace);
 }
@@ -28,29 +28,29 @@ export function deactivate(): void {
 }
 
 async function workspaceFoldersChanged(e: vscode.WorkspaceFoldersChangeEvent) {
-  await Promise.all(
-    e.added.map(async (folder) => {
-      await symbols.cacheWorkspaceFolder(folder);
-    }),
-  );
-  e.removed.forEach((folder) => {
-    symbols.clearWorkspaceFolderCache(folder);
-  });
-  symbols.syncWorkspaceCache();
+  // await Promise.all(
+  //   e.added.map(async (folder) => {
+  //     await symbols.cacheWorkspaceFolder(folder);
+  //   }),
+  // );
+  // e.removed.forEach((folder) => {
+  //   symbols.clearWorkspaceFolderCache(folder);
+  // });
+  // symbols.syncWorkspaceCache();
 }
 
-function documentChanged(e: vscode.TextDocumentChangeEvent) {
-  const { document, contentChanges } = e;
-  console.log('[documentChanged]', document.fileName, contentChanges);
-  if (document.languageId === 'zoneinfo' && contentChanges.length === 0) {
-    symbols.markDocumentDirty(document);
-  }
-}
+// function documentChanged(e: vscode.TextDocumentChangeEvent) {
+//   const { document, contentChanges } = e;
+//   console.log('[documentChanged]', document.fileName, contentChanges);
+//   if (document.languageId === 'zoneinfo' && contentChanges.length === 0) {
+//     symbols.markDocumentDirty(document);
+//   }
+// }
 
-function documentSaved(document: vscode.TextDocument) {
-  console.log('[documentSaved]', document.fileName);
-  symbols.cacheDocument(document);
-}
+// function documentSaved(document: vscode.TextDocument) {
+//   console.log('[documentSaved]', document.fileName);
+//   symbols.cacheDocument(document);
+// }
 
 class ZoneinfoDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
   public toSymbolInformation(allSymbols: ZoneSymbol[]): vscode.SymbolInformation[] {
@@ -66,7 +66,7 @@ class ZoneinfoDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
   ): Promise<vscode.SymbolInformation[]> {
     console.log('[provideDocumentSymbols]', document);
     const logTime = timer();
-    const docSymbols = await symbols.getForDocument(document);
+    const docSymbols = symbols.getForDocument(document);
     let ret = this.uniqueSymbols(docSymbols);
     logTime('provideDocumentSymbols');
     return ret;
@@ -111,7 +111,7 @@ class ZoneinfoWorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider 
   public async provideWorkspaceSymbols(query: string): Promise<vscode.SymbolInformation[]> {
     console.log('[provideWorkspaceSymbols]', query);
     const logTime = timer();
-    const allSymbols = await symbols.getForCurrentWorkspace();
+    const allSymbols = await symbols.getForWorkspace();
     logTime('provideWorkspaceSymbols: get');
     let ret = this.filteredSymbols(allSymbols, query);
     logTime('provideWorkspaceSymbols: filter');
@@ -126,7 +126,7 @@ class ZoneinfoDefinitionProvider implements vscode.DefinitionProvider {
   ): Promise<vscode.Definition> {
     console.log('[provideDefinition]', document, position);
     const logTime = timer();
-    const span = await symbols.getSpanForDocumentPosition(document, position);
+    const span = symbols.getSpanForDocumentPosition(document, position);
     logTime('provideDefinition: getSpan');
     if (span === null) {
       console.log('  (no matching span)');
@@ -146,7 +146,7 @@ class ZoneinfoReferenceProvider implements vscode.ReferenceProvider {
   ): Promise<vscode.Location[]> {
     console.log('[provideReferences]', document, position);
     const logTime = timer();
-    const span = await symbols.getSpanForDocumentPosition(document, position);
+    const span = symbols.getSpanForDocumentPosition(document, position);
     logTime('provideReferences: getSpan');
     if (span === null) {
       return null;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,15 +24,11 @@ export function activate(context: vscode.ExtensionContext): void {
 
 async function workspaceFoldersChanged(e: vscode.WorkspaceFoldersChangeEvent) {
   // Clear any cached folder/document symbols for removed folders
-  e.removed.forEach((folder) => {
-    symbols.removeForFolder(folder);
-  });
+  e.removed.forEach(symbols.removeForFolder);
   // Parse and cache new folders, but only if the whole workspace has been previously cached.
   // Otherwise, rely on the usual lazy-loading behaviour within a folder.
   if (symbols.hasCachedWorkspace()) {
-    e.added.forEach((folder) => {
-      symbols.getForFolder(folder);
-    });
+    e.added.forEach(symbols.getForFolder);
   }
 }
 

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,0 +1,16 @@
+import { createHash } from 'crypto';
+import { TextDocument } from 'vscode';
+
+/**
+ * Generate a sha256 hash of a string
+ */
+export function contentHash(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+/**
+ * Generate a sha256 hash of a document's contents.
+ */
+export function documentHash(document: TextDocument): string {
+  return contentHash(document.getText());
+}

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -111,6 +111,13 @@ export function getForDocument(document: vscode.TextDocument): ZoneSymbol[] {
 }
 
 /**
+ * Return true if a document already been parsed and cached.
+ */
+export function hasCachedDocument(document: vscode.TextDocument): boolean {
+  return Boolean(cache.getForDocument(document));
+}
+
+/**
  * Get all symbols for relevant documents within a folder.
  * Uses a cached list if the folder has previously been parsed.
  */

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,83 +1,188 @@
-'use strict';
-
 import * as vscode from 'vscode';
+
+import { documentHash } from './hash';
 import * as cache from './symbol-cache';
 import * as parser from './symbol-parser';
 import { ZoneSymbol, ZoneSymbolTextSpan } from './zone-symbol';
+import { timer } from './debug';
 
-export async function cacheCurrentWorkspace(): Promise<ZoneSymbol[]> {
+/**
+ * Get all symbols for a document and sync them with the cache.
+ * This will only parse the document for symbols when the document's content hash doesn't match
+ * the cached value.
+ */
+function updateDocument(document: vscode.TextDocument): {
+  symbols: ZoneSymbol[],
+  didUpdate: boolean,
+} {
+  let filename = document.fileName.split('/').pop();
+  console.log(`[updateDocument ${filename}]`);
+  let logTime = timer();
+  let shouldUpdate = false;
+  let symbols: ZoneSymbol[] = [];
+  const hash = documentHash(document);
+  const cachedDocument = cache.getForDocument(document);
+  logTime(`[updateDocument ${filename}]: hash and get`);
+  if (!cachedDocument) {
+    console.log(`[updateDocument ${filename}]: not in cache`);
+    shouldUpdate = true;
+  } else {
+    console.log(`[updateDocument ${filename}]: already cached`);
+    symbols = cachedDocument.symbols;
+    if (cachedDocument.hash !== hash) {
+      console.log(`[updateDocument ${filename}]: cached hash didn't match`);
+      shouldUpdate = true;
+    }
+  }
+
+  if (shouldUpdate) {
+    console.log(`[updateDocument ${filename}]: parsing`);
+    symbols = parser.parseDocument(document);
+    cache.setForDocument(document, hash, symbols);
+  }
+  logTime(`[updateDocument ${filename}]: total`);
+  return { symbols, didUpdate: shouldUpdate };
+}
+
+// TODO: Copied from symbol-parser, clean this up
+type DocumentSymbols = { file: vscode.Uri; symbols: ZoneSymbol[] };
+type FolderSymbols = { path: string; documents: DocumentSymbols[] };
+
+/**
+ * Get all symbols for documents within a folder, parsing only the ones that haven't been cached.
+ */
+async function updateFolder(folder: vscode.WorkspaceFolder): Promise<{
+  path: string,
+  documents: DocumentSymbols[],
+}> {
+  console.log(`[updateFolder] ${folder.name}`);
+  let logTime = timer();
+  const filenames = `{${parser.PARSEABLE_FILENAMES.join(',')}}`;
+  const findArg = new vscode.RelativePattern(folder, filenames);
+  const files: vscode.Uri[] = await vscode.workspace.findFiles(findArg);
+  logTime(`[updateFolder: ${folder.name}]: findFiles`);
+  
+  let docSymbols: DocumentSymbols[] = [];
+  let openDocuments = vscode.workspace.textDocuments;
+  console.log('  [openDocuments]', openDocuments.map(doc => doc.fileName));
+  for (let file of files) {
+    docSymbols.push(await (async () => {
+      let filename = file.toString().split('/').pop();
+      let logFileTime = timer();
+
+      const doc = await vscode.workspace.openTextDocument(file);
+      logFileTime(`${filename}: open`);
+      const { symbols } = updateDocument(doc);
+      logFileTime(`${filename}: parse/cache`);
+
+      return { file, symbols };
+    })());
+  }
+  const path = folder.uri.toString();
+  logTime(`[updateFolder: ${folder.name}]: TOTAL`);
+
+  // TODO: Do I actually need to return DocumentSymbols here?
+  return {
+    path,
+    documents: docSymbols,
+  }
+}
+
+/**
+ * Get all symbols for relevant documents within the current workspace.
+ */
+async function updateWorkspace(): Promise<{
+  folders: FolderSymbols[],
+}> {
   const start = Date.now();
-  const folders = await parser.parseCurrentWorkspace();
-  folders.forEach(({ path, documents }) => {
-    let folderSymbols: ZoneSymbol[] = [];
-    documents.forEach(({ file, symbols }) => {
-      cache.setForDocument(file, symbols);
-      folderSymbols = folderSymbols.concat(symbols);
-    });
-    cache.setForWorkspaceFolder(path, folderSymbols);
-  });
-  let res = cache.updateAllForCurrentWorkspace();
+  let folders = vscode.workspace.workspaceFolders;
+  if (folders === undefined || !folders.length) {
+    return {
+      folders: [],
+    };
+  }
+
+  let ret: FolderSymbols[] = [];
+  for (let folder of folders) {
+    ret.push(await (async () => {
+      // TODO: Only parse folders that aren't already cached
+      const { path, documents } = await updateFolder(folder);
+
+      return { path, documents };
+    })());
+  }
   const end = Date.now();
-  console.log(`CACHING TOOK ${end - start}`);
-  return res;
+  console.log(`[updateWorkspace] TOOK ${end - start}`);
+  
+  return { folders: ret };
 }
 
-export async function cacheWorkspaceFolder(folder: vscode.WorkspaceFolder): Promise<ZoneSymbol[]> {
-  const parsed = await parser.parseWorkspaceFolder(folder);
-  let folderSymbols: ZoneSymbol[] = [];
-  parsed.documents.forEach(({ file, symbols }) => {
-    cache.setForDocument(file, symbols);
-    folderSymbols = folderSymbols.concat(symbols);
+/**
+ * Get all symbols for a document.
+ */
+export function getForDocument(document: vscode.TextDocument): ZoneSymbol[] {
+  const updateResult = updateDocument(document);
+  return updateResult.symbols;
+}
+
+/**
+ * Get all symbols for relevant documents within a folder.
+ * Uses a cached list if the folder has previously been parsed.
+ */
+export async function getForFolder(folder: vscode.WorkspaceFolder): Promise<ZoneSymbol[]> {
+  console.log(`[getForFolder] ${folder.name}`);
+  const cached = cache.getForFolder(folder);
+  if (cached) {
+    return cached.symbols;
+  }
+  console.log('  (not cached, parsing...)');
+  const parsed = await updateFolder(folder);
+  // TODO: Move everything below into updateFolder() ?
+  let allSymbols = parsed.documents.flatMap(doc => doc.symbols);
+  cache.setForFolder(folder, allSymbols);
+  return allSymbols;
+}
+
+/**
+ * Get all symbols for relevant documents within the current workspace.
+ * Uses a cached list if all folders in the workspace have previously been parsed.
+ */
+export async function getForWorkspace(): Promise<ZoneSymbol[]> {
+  console.log('[getForWorkspace]');
+  const cached = cache.getForWorkspace();
+  if (cached) {
+    return cached.symbols;
+  }
+  console.log('  (not cached, parsing...)');
+  const parsed = await updateWorkspace();
+  // TODO: Move everything below into updateWorkspace() ?
+  let allSymbols = parsed.folders.flatMap(folder => {
+    let folderSymbols = folder.documents.flatMap(doc => doc.symbols);
+    cache.setForFolder(folder.path, folderSymbols);
+    return folderSymbols;
   });
-  cache.setForWorkspaceFolder(parsed.path, folderSymbols);
-  return folderSymbols;
+  cache.setForWorkspace(allSymbols);
+  return allSymbols;
 }
 
-export function syncWorkspaceCache(): void {
-  cache.updateAllForCurrentWorkspace();
-}
-
-export function clearCache(): void {
-  cache.clear();
-}
-
-export function clearWorkspaceFolderCache(folder: vscode.WorkspaceFolder): void {
-  cache.clearForWorkspaceFolder(folder);
-}
-
-export async function getForCurrentWorkspace(): Promise<ZoneSymbol[]> {
-  console.log('[getForCurrentWorkspace: known documents]', vscode.workspace.textDocuments);
-  const symbols = cache.getForCurrentWorkspace();
-  if (symbols === null) {
-    return cacheCurrentWorkspace();
-  }
-  return Promise.resolve(symbols);
-}
-
-export async function getForDocument(document: vscode.TextDocument): Promise<ZoneSymbol[]> {
-  const fileCache = cache.getForDocument(document);
-  const shouldParse = !fileCache || fileCache.isDirty;
-  if (shouldParse) {
-    return cacheDocument(document);
-  }
-  return Promise.resolve(fileCache.symbols);
-}
-
-export async function cacheDocument(document: vscode.TextDocument): Promise<ZoneSymbol[]> {
-  const symbols = parser.parseDocument(document);
-  cache.setForDocument(document, symbols);
-  return Promise.resolve(symbols);
-}
-
+/**
+ * Get all symbols with names that match a given text span.
+ * Symbols are restricted to the same workspace folder as the text span.
+ */
 export async function getForSpan(span: ZoneSymbolTextSpan): Promise<ZoneSymbol[]> {
-  const folder = cache.getWorkspaceFolderForDocument(span.location.uri);
-  const allSymbols = await cache.getForWorkspaceFolder(folder);
+  const folder = vscode.workspace.getWorkspaceFolder(span.location.uri);
+  const allSymbols = await getForFolder(folder);
   return allSymbols.filter((s) => s.name.text === span.text);
 }
 
+/**
+ * Get all text spans for symbols that link to a given text span.
+ * This is primarily used for finding references to a location.
+ * Text spans are restricted to the same workspace folder as the text span.
+ */
 export async function getSpanLinksToName(span: ZoneSymbolTextSpan): Promise<ZoneSymbolTextSpan[]> {
-  const folder = cache.getWorkspaceFolderForDocument(span.location.uri);
-  const allSymbols = await cache.getForWorkspaceFolder(folder);
+  const folder = vscode.workspace.getWorkspaceFolder(span.location.uri);
+  const allSymbols = await getForFolder(folder);
   return allSymbols
     .map((symbol) => {
       if (symbol.name.text === span.text) {
@@ -88,11 +193,15 @@ export async function getSpanLinksToName(span: ZoneSymbolTextSpan): Promise<Zone
     .reduce((all, spans) => all.concat(spans), []);
 }
 
-export async function getSpanForDocumentPosition(
+/**
+ * Get a text span for a symbol that includes the given document position.
+ * Returns null if there are no symbols matching the position.
+ */
+export function getSpanForDocumentPosition(
   document: vscode.TextDocument,
   position: vscode.Position,
-): Promise<ZoneSymbolTextSpan> {
-  const docSymbols = await getForDocument(document);
+): ZoneSymbolTextSpan {
+  const docSymbols = getForDocument(document);
   for (let symbol of docSymbols) {
     if (symbol.name.location.range.contains(position)) {
       return symbol.name;
@@ -106,10 +215,9 @@ export async function getSpanForDocumentPosition(
   return null;
 }
 
-export function markDocumentDirty(document: vscode.TextDocument): void {
-  cache.setDocumentDirtyState(document, true);
-}
-
+/**
+ * De-duplicate a list of symbols.
+ */
 export function unique(symbols: ZoneSymbol[]): ZoneSymbol[] {
   let used = new Set();
   return symbols.filter((symbol) => {

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -6,6 +6,7 @@ import * as parser from './symbol-parser';
 import { ZoneSymbol, ZoneSymbolTextSpan } from './zone-symbol';
 
 export async function cacheCurrentWorkspace(): Promise<ZoneSymbol[]> {
+  const start = Date.now();
   const folders = await parser.parseCurrentWorkspace();
   folders.forEach(({ path, documents }) => {
     let folderSymbols: ZoneSymbol[] = [];
@@ -15,7 +16,10 @@ export async function cacheCurrentWorkspace(): Promise<ZoneSymbol[]> {
     });
     cache.setForWorkspaceFolder(path, folderSymbols);
   });
-  return cache.updateAllForCurrentWorkspace();
+  let res = cache.updateAllForCurrentWorkspace();
+  const end = Date.now();
+  console.log(`CACHING TOOK ${end - start}`);
+  return res;
 }
 
 export async function cacheWorkspaceFolder(folder: vscode.WorkspaceFolder): Promise<ZoneSymbol[]> {
@@ -42,6 +46,7 @@ export function clearWorkspaceFolderCache(folder: vscode.WorkspaceFolder): void 
 }
 
 export async function getForCurrentWorkspace(): Promise<ZoneSymbol[]> {
+  console.log('[getForCurrentWorkspace: known documents]', vscode.workspace.textDocuments);
   const symbols = cache.getForCurrentWorkspace();
   if (symbols === null) {
     return cacheCurrentWorkspace();

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -90,10 +90,8 @@ async function updateWorkspace(): Promise<ZoneSymbol[]> {
   const logTime = timer();
   let folderSymbols: ZoneSymbol[][] = [];
   for (let folder of folders) {
-    folderSymbols.push(await (async () => {
-      // Use getForFolder() to avoid re-parsing folders that are already cached
-      return await getForFolder(folder);
-    })());
+    // Use getForFolder() to avoid re-parsing folders that are already cached
+    folderSymbols.push(await getForFolder(folder));
   }
   logTime('[updateWorkspace]: TOTAL');
   
@@ -179,14 +177,12 @@ export async function getForSpan(span: ZoneSymbolTextSpan): Promise<ZoneSymbol[]
 export async function getSpanLinksToName(span: ZoneSymbolTextSpan): Promise<ZoneSymbolTextSpan[]> {
   const folder = vscode.workspace.getWorkspaceFolder(span.location.uri);
   const allSymbols = await getForFolder(folder);
-  return allSymbols
-    .map((symbol) => {
-      if (symbol.name.text === span.text) {
-        return [symbol.name];
-      }
-      return symbol.references.filter((ref) => ref.text === span.text);
-    })
-    .reduce((all, spans) => all.concat(spans), []);
+  return allSymbols.flatMap((symbol) => {
+    if (symbol.name.text === span.text) {
+      return [symbol.name];
+    }
+    return symbol.references.filter((ref) => ref.text === span.text);
+  });
 }
 
 /**


### PR DESCRIPTION
This changes the parsing / caching of file symbols to be lazy-loaded, instead of parsing the whole workspace on extension activation. This addresses some of the performance concerns in #6.

This is mostly here for my own reference, to make sure all the changes make sense as a whole.